### PR TITLE
python3 instead of python2

### DIFF
--- a/airspy_m0/airspy_m0.c
+++ b/airspy_m0/airspy_m0.c
@@ -73,13 +73,13 @@ volatile airspy_mcore_t *set_packing = (airspy_mcore_t *)((&cm0_data_share)+2);
 uint8_t* const usb_bulk_buffer = (uint8_t*)0x20004000;
 
 const char version_string[] = " " AIRSPY_FW_GIT_TAG " " AIRSPY_FW_CHECKIN_DATE;
-
+/*
 typedef struct {
   uint32_t freq_hz;
 } set_freq_params_t;
 
 set_freq_params_t set_freq_params;
-
+*/
 typedef struct {
   uint32_t freq_hz;
   uint32_t divider;

--- a/common/Makefile_M0_inc.mk
+++ b/common/Makefile_M0_inc.mk
@@ -134,6 +134,6 @@ FORCE:
 # Anything that depends on FORCE will be considered out-of-date
 %.hdr: FORCE
 	echo Creating $@
-	python ../scripts/airspy_fw-version.py ./$@
+	python3 ../scripts/airspy_fw-version.py ./$@
 
 -include $(OBJ:.o=.d)

--- a/common/Makefile_M0s_inc.mk
+++ b/common/Makefile_M0s_inc.mk
@@ -134,6 +134,6 @@ FORCE:
 # Anything that depends on FORCE will be considered out-of-date
 %.hdr: FORCE
 	echo Creating $@
-	python ../scripts/airspy_fw-version.py ./$@
+	python3 ../scripts/airspy_fw-version.py ./$@
 
 -include $(OBJ:.o=.d)


### PR DESCRIPTION
using the default "python" executable on my system fails due to it being linked to python2, also some other compile error i was having seems to be fixed, or at least seems to allow it to compile without throwing an error...